### PR TITLE
enhancement/path of the cycled vertices

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,7 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": []
+}

--- a/graph.go
+++ b/graph.go
@@ -484,7 +484,7 @@ func TopologicalSort(vertices []*Vertex) ([]*Vertex, error) {
 					buf.WriteString(fmt.Sprintf("vertex: %s -> ", vertices[i].ID))
 				}
 			}
-			return nil, errors.E(op, errors.Errorf("cycle detected, please, check the path: %s", strings.TrimRight(buf.String(), " -> ")))
+			return nil, errors.E(op, errors.Errorf("cycle detected, please, check the path: %s", strings.TrimRight(buf.String(), "-> ")))
 		}
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -1,7 +1,6 @@
 package endure
 
 import (
-	"bytes"
 	"fmt"
 	"reflect"
 	"strings"
@@ -475,15 +474,18 @@ func TopologicalSort(vertices []*Vertex) ([]*Vertex, error) {
 		verticesCopy = verticesCopy[:len(verticesCopy)-1]
 		containsCycle := dfs(vertex, &ord)
 		if containsCycle {
-			buf := new(bytes.Buffer)
-			defer buf.Truncate(0)
+			// allocate a buffer for the resulting message
+			buf := new(strings.Builder)
+			// defer buffer reset
+			defer buf.Reset()
 			buf.WriteString("The following vertices involved:\n")
-			// If we found a cycle, print involved vertices
+			// If we found a cycle, print involved vertices in reverse order
 			for i := (len(vertices) - 1); i > 0; i-- {
 				if vertices[i].visited == false {
 					buf.WriteString(fmt.Sprintf("vertex: %s -> ", vertices[i].ID))
 				}
 			}
+			// trim the last arrow and return error message
 			return nil, errors.E(op, errors.Errorf("cycle detected, please, check the path: %s", strings.TrimRight(buf.String(), "-> ")))
 		}
 	}

--- a/graph.go
+++ b/graph.go
@@ -1,8 +1,10 @@
 package endure
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 
 	"github.com/spiral/errors"
@@ -473,13 +475,16 @@ func TopologicalSort(vertices []*Vertex) ([]*Vertex, error) {
 		verticesCopy = verticesCopy[:len(verticesCopy)-1]
 		containsCycle := dfs(vertex, &ord)
 		if containsCycle {
+			buf := new(bytes.Buffer)
+			defer buf.Truncate(0)
+			buf.WriteString("The following vertices involved:\n")
 			// If we found a cycle, print involved vertices
-			for i := 0; i < len(vertices); i++ {
+			for i := (len(vertices) - 1); i > 0; i-- {
 				if vertices[i].visited == false {
-					fmt.Println(vertices[i].ID)
+					buf.WriteString(fmt.Sprintf("vertex: %s -> ", vertices[i].ID))
 				}
 			}
-			return nil, errors.E(op, errors.Errorf("cycle detected, please, check vertex: %s", vertex.ID))
+			return nil, errors.E(op, errors.Errorf("cycle detected, please, check the path: %s", strings.TrimRight(buf.String(), " -> ")))
 		}
 	}
 


### PR DESCRIPTION
Now endure will show the full path of cycled vertices:
```
topological sort: cycle detected, please, check the path: The following vertices involved:
vertex: server.Plugin -> vertex: rpc.Plugin -> vertex: informer.Plugin -> vertex: http.Plugin
```
Here we can see, that we have a cycle and 4 involved plugins. The next step of improvement:
endure should show particular dependency, which causes the cycle.
closes #73 