### PR TITLE
bug(disabled vertices): Fix for the disabled vertices issue

### DIFF
--- a/pkg/container/init.go
+++ b/pkg/container/init.go
@@ -25,6 +25,9 @@ func (e *Endure) internalInit(vrtx *vertex.Vertex) error {
 
 	err := e.callInitFn(initMethod, vrtx)
 	if err != nil {
+		if errors.Is(errors.Disabled, err) {
+			return err
+		}
 		e.logger.Error("error occurred during the call INIT function", zap.String("vertex id", vrtx.ID), zap.Error(err))
 		return errors.E(op, errors.FunctionCall, err)
 	}
@@ -64,11 +67,8 @@ func (e *Endure) callInitFn(init reflect.Method, vrtx *vertex.Vertex) error {
 				e.logger.Warn("vertex disabled", zap.String("vertex id", vrtx.ID), zap.Error(err))
 				// disable current vertex
 				vrtx.IsDisabled = true
-				// disable all vertices in the vertex which depends on current
-				// TODO better solution (remove vertex)
-				// e.graph.DisableByID(vertex.ID)
 				// Disabled is actually to an error, just notification to the graph, that it has some vertices which are disabled
-				return nil
+				return errors.E(op, errors.Disabled)
 			}
 
 			e.logger.Error("error calling internal_init", zap.String("vertex id", vrtx.ID), zap.Error(err))

--- a/pkg/container/options.go
+++ b/pkg/container/options.go
@@ -1,0 +1,42 @@
+package endure
+
+import "time"
+
+// SetLogLevel option sets the log level in the Endure
+func SetLogLevel(lvl Level) Options {
+	return func(endure *Endure) {
+		endure.loglevel = lvl
+	}
+}
+
+// RetryOnFail if set to true, endure will try to stop and restart graph if one or more vertices are failed
+func RetryOnFail(retry bool) Options {
+	return func(endure *Endure) {
+		endure.retry = retry
+	}
+}
+
+// SetBackoffTimes sets initial and maximum backoff interval for retry
+func SetBackoffTimes(initialInterval time.Duration, maxInterval time.Duration) Options {
+	return func(endure *Endure) {
+		endure.maxInterval = maxInterval
+		endure.initialInterval = initialInterval
+	}
+}
+
+// Visualize visualize current graph. Output: can be file or stdout
+func Visualize(output Output, path string) Options {
+	return func(endure *Endure) {
+		endure.output = output
+		if path != "" {
+			endure.path = path
+		}
+	}
+}
+
+// SetStopTimeOut sets the timeout to kill the vertices is one or more of them are frozen
+func SetStopTimeOut(to time.Duration) Options {
+	return func(endure *Endure) {
+		endure.stopTimeout = to
+	}
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -29,6 +29,9 @@ type Graph struct {
 	Vertices []*vertex.Vertex
 
 	Providers map[string]reflect.Value
+
+	// internal type
+	InitialProviders map[string]reflect.Value
 }
 
 // NewGraph initializes endure Graph
@@ -51,6 +54,14 @@ func (g *Graph) AddGlobalProvider(providedID string, val reflect.Value) {
 func (g *Graph) HasVertex(name string) bool {
 	_, ok := g.VerticesMap[name]
 	return ok
+}
+
+// Replace providers with initial
+func (g *Graph) ClearState() {
+	g.Providers = make(map[string]reflect.Value)
+	g.VerticesMap = make(map[string]*vertex.Vertex)
+	// delete from Vertices
+	g.Vertices = make([]*vertex.Vertex, 0)
 }
 
 /*


### PR DESCRIPTION
# Reason for This PR

temporarily fixes #81 

## Description of Changes

1. Not an elegant solution, but work well. After endure found Disabled vertex (on the Init stage), it clears the graph state keeping in mind the disabled vertex. If after deletion of the disabled vertex, endure can't build dependencies, it fails with the error message. But at the end, all disabled vertices are filtered and not presented in the `Collects` or `Init`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
~- [ ] Any required documentation changes (code and docs) are included in this PR.~
~- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.~
- [x] All added/changed functionality is tested.
